### PR TITLE
Increase the density of tall by-object prints

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -60,21 +60,21 @@ jobs:
       arch: ${{ matrix.arch }}
       build-deps-only: ${{ inputs.build-deps-only || false }}
     secrets: inherit
-  flatpak:
-    name: "Flatpak"
-    runs-on: ubuntu-latest
-    container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
-      options: --privileged
-    steps:
-    # maybe i'm too dumb and fucked up to do CI. OH WELL :D -ppd
-    - name: "Remove unneeded stuff to free disk space"
-      run:
-        sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY"
-    - uses: actions/checkout@v4
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
-      with:
-        bundle: orcaslicer.flatpak
-        manifest-path: flatpak/io.github.softfever.OrcaSlicer.yml
-        cache-key: flatpak-builder-${{ github.sha }}
-        cache: false
+  # flatpak:
+  #   name: "Flatpak"
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: bilelmoussaoui/flatpak-github-actions:gnome-46
+  #     options: --privileged
+  #   steps:
+  #   # maybe i'm too dumb and fucked up to do CI. OH WELL :D -ppd
+  #   - name: "Remove unneeded stuff to free disk space"
+  #     run:
+  #       sudo rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY"
+  #   - uses: actions/checkout@v4
+  #   - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+  #     with:
+  #       bundle: orcaslicer.flatpak
+  #       manifest-path: flatpak/io.github.softfever.OrcaSlicer.yml
+  #       cache-key: flatpak-builder-${{ github.sha }}
+  #       cache: false

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -47,13 +47,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-          - os: ubuntu-24.04
+          # - os: ubuntu-20.04
+          # - os: ubuntu-24.04
           - os: windows-latest
-          - os: macos-14
-            arch: x86_64
-          - os: macos-14
-            arch: arm64
+          # - os: macos-14
+          #   arch: x86_64
+          # - os: macos-14
+          #   arch: arm64
     uses: ./.github/workflows/build_check_cache.yml
     with:
       os: ${{ matrix.os }}

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -850,10 +850,10 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                 // Assuming that the rod is located within the tool head, the distance from the nozzle to the rod must
                 // be less than the tool head clearance radius. Therefore, it is safe to shrink the intersection range
                 // by the real rod distance.
-                float py1 = bbox2.min.y();
-                float py2 = bbox2.max.y();
-                auto inter_min = std::max(iy1, py1 + tool_head_rod_distance_front); // min y of intersection
-                auto inter_max = std::min(iy2, py2 - tool_head_rod_distance_back); // max y of intersection. length=max_y-min_y>0 means intersection exists
+                auto py1 = bbox2.min.y();
+                auto py2 = bbox2.max.y();
+                auto inter_min = std::max(iy1, py1); // min y of intersection
+                auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
                 if (inter_max - inter_min > 0) {
                     // We set the maximum allowed height for `inst` to extruder_clearance_height_to_rod here. If `inst`
                     // is higher than extruder_clearance_height_to_rod, and `p` overlaps `inst` over the y axis, then

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -815,6 +815,9 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
 
         // if objects are not overlapped on y-axis, they will not collide even if they are taller than extruder_clearance_height_to_rod
         int print_instance_count = print_instance_with_bounding_box.size();
+        // TODO: move rod distance params to the printer profile
+        float tool_head_rod_distance_back = 15.0; // distance from the rod to the back of the tool head
+        float tool_head_rod_distance_front = 47.0; // distance from the rod to the front of the tool head
         std::map<const PrintInstance*, std::pair<Polygon, float>> too_tall_instances;
         for (int k = 0; k < print_instance_count; k++)
         {
@@ -839,9 +842,6 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
             for (int i = k+1; i < print_instance_count; i++)
             {
                 auto& p = print_instance_with_bounding_box[i].print_instance;
-                // TODO: move rod distance params to the printer profile
-                float tool_head_rod_distance_back = 15.0f; // distance from the rod to the back of the tool head
-                float tool_head_rod_distance_front = 47.0f; // distance from the rod to the front of the tool head
                 auto bbox2 = print_instance_with_bounding_box[i].bounding_box;
                 // bbox2 is bigger than it needs to be because it is inflated by the extruder_clearance_radius. We
                 // shrink the intersection range by the measured distance to the rod, but we do not account for the real
@@ -850,10 +850,10 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                 // Assuming that the rod is located within the tool head, the distance from the nozzle to the rod must
                 // be less than the tool head clearance radius. Therefore, it is safe to shrink the intersection range
                 // by the real rod distance.
-                float py1 = bbox2.min.y() + tool_head_rod_distance_front;
-                float py2 = bbox2.max.y() - tool_head_rod_distance_back;
-                auto inter_min = std::max(iy1, py1); // min y of intersection
-                auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
+                float py1 = bbox2.min.y();
+                float py2 = bbox2.max.y();
+                auto inter_min = std::max(iy1, py1 + tool_head_rod_distance_front); // min y of intersection
+                auto inter_max = std::min(iy2, py2 - tool_head_rod_distance_back); // max y of intersection. length=max_y-min_y>0 means intersection exists
                 if (inter_max - inter_min > 0) {
                     // We set the maximum allowed height for `inst` to extruder_clearance_height_to_rod here. If `inst`
                     // is higher than extruder_clearance_height_to_rod, and `p` overlaps `inst` over the y axis, then

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -816,8 +816,8 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
         // if objects are not overlapped on y-axis, they will not collide even if they are taller than extruder_clearance_height_to_rod
         int print_instance_count = print_instance_with_bounding_box.size();
         // TODO: move rod distance params to the printer profile
-        float tool_head_rod_distance_back = 15.0; // distance from the rod to the back of the tool head
-        float tool_head_rod_distance_front = 47.0; // distance from the rod to the front of the tool head
+        double tool_head_rod_distance_back = 15.0; // distance from the rod to the back of the tool head
+        double tool_head_rod_distance_front = 47.0; // distance from the rod to the front of the tool head
         std::map<const PrintInstance*, std::pair<Polygon, float>> too_tall_instances;
         for (int k = 0; k < print_instance_count; k++)
         {
@@ -852,8 +852,8 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                 // by the real rod distance.
                 auto py1 = bbox2.min.y();
                 auto py2 = bbox2.max.y();
-                auto inter_min = std::max(iy1, py1); // min y of intersection
-                auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
+                auto inter_min = std::max(iy1, py1 + tool_head_rod_distance_front); // min y of intersection
+                auto inter_max = std::min(iy2, py2 - tool_head_rod_distance_back); // max y of intersection. length=max_y-min_y>0 means intersection exists
                 if (inter_max - inter_min > 0) {
                     // We set the maximum allowed height for `inst` to extruder_clearance_height_to_rod here. If `inst`
                     // is higher than extruder_clearance_height_to_rod, and `p` overlaps `inst` over the y axis, then

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -854,8 +854,8 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                 // is measured instead of the distance to the front of the tool head. Then we can shrink py1 by
                 // rod->nozzle distance + extruder_clearance_radius. But then we need to add some kind of margin in case
                 // there supports are generated outside of the printed object.
-                auto py1 = bbox2.min.y() + tool_head_rod_distance_front;
-                auto py2 = bbox2.max.y() - tool_head_rod_distance_back;
+                float py1 = bbox2.min.y() + tool_head_rod_distance_front;
+                float py2 = bbox2.max.y() - tool_head_rod_distance_back;
                 auto inter_min = std::max(iy1, py1); // min y of intersection
                 auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
                 if (inter_max - inter_min > 0) {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -850,10 +850,6 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                 // Assuming that the rod is located within the tool head, the distance from the nozzle to the rod must
                 // be less than the tool head clearance radius. Therefore, it is safe to shrink the intersection range
                 // by the real rod distance.
-                // FIXME: The range shrinkage calculation can be improved if the distance between the rod and the nozzle
-                // is measured instead of the distance to the front of the tool head. Then we can shrink py1 by
-                // rod->nozzle distance + extruder_clearance_radius. But then we need to add some kind of margin in case
-                // there supports are generated outside of the printed object.
                 float py1 = bbox2.min.y() + tool_head_rod_distance_front;
                 float py2 = bbox2.max.y() - tool_head_rod_distance_back;
                 auto inter_min = std::max(iy1, py1); // min y of intersection

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -840,8 +840,8 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
             {
                 auto& p = print_instance_with_bounding_box[i].print_instance;
                 // TODO: move rod distance params to the printer profile
-                float tool_head_rod_distance_back = 15.0f; // distance from the rod to the back of the tool head
-                float tool_head_rod_distance_front = 47.0f; // distance from the rod to the front of the tool head
+                auto tool_head_rod_distance_back = 15.0f; // distance from the rod to the back of the tool head
+                auto tool_head_rod_distance_front = 47.0f; // distance from the rod to the front of the tool head
                 auto bbox2 = print_instance_with_bounding_box[i].bounding_box;
                 // bbox2 is bigger than it needs to be because it is inflated by the extruder_clearance_radius. We
                 // shrink the intersection range by the measured distance to the rod, but we do not account for the real
@@ -854,8 +854,8 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                 // is measured instead of the distance to the front of the tool head. Then we can shrink py1 by
                 // rod->nozzle distance + extruder_clearance_radius. But then we need to add some kind of margin in case
                 // there supports are generated outside of the printed object.
-                float py1 = bbox2.min.y() + tool_head_rod_distance_front;
-                float py2 = bbox2.max.y() - tool_head_rod_distance_back;
+                auto py1 = bbox2.min.y() + tool_head_rod_distance_front;
+                auto py2 = bbox2.max.y() - tool_head_rod_distance_back;
                 auto inter_min = std::max(iy1, py1); // min y of intersection
                 auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
                 if (inter_max - inter_min > 0) {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -840,8 +840,8 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
             {
                 auto& p = print_instance_with_bounding_box[i].print_instance;
                 // TODO: move rod distance params to the printer profile
-                auto tool_head_rod_distance_back = 15.0f; // distance from the rod to the back of the tool head
-                auto tool_head_rod_distance_front = 47.0f; // distance from the rod to the front of the tool head
+                float tool_head_rod_distance_back = 15.0f; // distance from the rod to the back of the tool head
+                float tool_head_rod_distance_front = 47.0f; // distance from the rod to the front of the tool head
                 auto bbox2 = print_instance_with_bounding_box[i].bounding_box;
                 // bbox2 is bigger than it needs to be because it is inflated by the extruder_clearance_radius. We
                 // shrink the intersection range by the measured distance to the rod, but we do not account for the real
@@ -854,8 +854,8 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                 // is measured instead of the distance to the front of the tool head. Then we can shrink py1 by
                 // rod->nozzle distance + extruder_clearance_radius. But then we need to add some kind of margin in case
                 // there supports are generated outside of the printed object.
-                auto py1 = bbox2.min.y() + tool_head_rod_distance_front;
-                auto py2 = bbox2.max.y() - tool_head_rod_distance_back;
+                float py1 = bbox2.min.y() + tool_head_rod_distance_front;
+                float py2 = bbox2.max.y() - tool_head_rod_distance_back;
                 auto inter_min = std::max(iy1, py1); // min y of intersection
                 auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
                 if (inter_max - inter_min > 0) {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -850,10 +850,10 @@ StringObjectException Print::sequential_print_clearance_valid(const Print &print
                 // Assuming that the rod is located within the tool head, the distance from the nozzle to the rod must
                 // be less than the tool head clearance radius. Therefore, it is safe to shrink the intersection range
                 // by the real rod distance.
-                auto py1 = bbox2.min.y();
-                auto py2 = bbox2.max.y();
-                auto inter_min = std::max(iy1, py1 + tool_head_rod_distance_front); // min y of intersection
-                auto inter_max = std::min(iy2, py2 - tool_head_rod_distance_back); // max y of intersection. length=max_y-min_y>0 means intersection exists
+                auto py1 = bbox2.min.y() + tool_head_rod_distance_front;
+                auto py2 = bbox2.max.y() - tool_head_rod_distance_back;
+                auto inter_min = std::max(iy1, py1); // min y of intersection
+                auto inter_max = std::min(iy2, py2); // max y of intersection. length=max_y-min_y>0 means intersection exists
                 if (inter_max - inter_min > 0) {
                     // We set the maximum allowed height for `inst` to extruder_clearance_height_to_rod here. If `inst`
                     // is higher than extruder_clearance_height_to_rod, and `p` overlaps `inst` over the y axis, then


### PR DESCRIPTION
Reduce the y axis intersection check only to the range where the 3d printer rod may be located during each object's print.

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
